### PR TITLE
Initialize Node skeleton per new plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,23 @@
 # AI Ad Agency
 
-This project implements an AI-powered advertising agency platform.  A Flask API
-provides endpoints for generating advertisement copy and managing user accounts.
-Future iterations will add targeting and optimization features.
+This project implements an AI-powered advertising agency platform. The current MVP uses a Node.js/Express backend with TypeScript and will eventually include a React frontend. Previous Python prototypes remain for reference.
 
 ## Technology Stack
-- Python 3.11 with Flask
-- (Planned) React with TypeScript for the frontend
+- Node.js with Express
+- TypeScript
+- MongoDB (planned)
+- React (planned for frontend)
 
 ## Development
 Install dependencies and start the API server:
 
 ```bash
-pip install -r requirements.txt
-python -m adagency.app
+npm install
+npm run dev
 ```
 
-Run unit tests:
+Run unit tests (requires dev dependencies):
 
 ```bash
-python -m unittest discover -s tests -v
+npm test
 ```

--- a/docs/specs/UniversalSpecForge_v5_Plan.json
+++ b/docs/specs/UniversalSpecForge_v5_Plan.json
@@ -1,0 +1,21 @@
+{
+  "projectName": "AI-Powered Advertising Agency Platform (MVP Focus)",
+  "overview": "MVP focuses on automated ad creation and targeting for Google Ads using a Node.js/Express backend, MongoDB, and a React frontend.",
+  "phases": {
+    "PHASE-MVP-001": {
+      "name": "MVP Development",
+      "tasks": [
+        "Implement User Registration and Login",
+        "Develop Ad Campaign Creation Workflow",
+        "Implement Automated Ad Generation",
+        "Integrate with Google Ads API"
+      ]
+    },
+    "PHASE-POSTMVP-002": {
+      "name": "Post-MVP Enhancement - Iteration 1",
+      "tasks": [
+        "Integrate with Facebook Ads API"
+      ]
+    }
+  }
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+export default {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/tests/**/*.test.ts']
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "ai-ad-agency",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/server.js",
+    "dev": "ts-node src/server.ts",
+    "test": "jest"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/jest": "^29.5.3",
+    "ts-jest": "^29.1.1",
+    "typescript": "^5.3.3",
+    "ts-node": "^10.9.1",
+    "jest": "^29.7.0",
+    "supertest": "^6.3.4"
+  }
+}

--- a/src/auth/service.ts
+++ b/src/auth/service.ts
@@ -1,0 +1,30 @@
+import crypto from 'crypto';
+
+interface User {
+  username: string;
+  passwordHash: string;
+  salt: string;
+}
+
+const users: Record<string, User> = {};
+
+function hashPassword(password: string, salt: string): string {
+  return crypto.pbkdf2Sync(password, salt, 100000, 64, 'sha512').toString('hex');
+}
+
+export function registerUser(username: string, password: string): boolean {
+  if (users[username]) {
+    return false;
+  }
+  const salt = crypto.randomBytes(16).toString('hex');
+  const passwordHash = hashPassword(password, salt);
+  users[username] = { username, passwordHash, salt };
+  return true;
+}
+
+export function authenticateUser(username: string, password: string): boolean {
+  const user = users[username];
+  if (!user) return false;
+  const attemptedHash = hashPassword(password, user.salt);
+  return attemptedHash === user.passwordHash;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,31 @@
+import express from 'express';
+import { registerUser, authenticateUser } from './auth/service';
+
+const app = express();
+app.use(express.json());
+
+app.post('/register', (req, res) => {
+  const { username, password } = req.body || {};
+  if (!username || !password) {
+    return res.status(400).json({ error: 'missing_fields' });
+  }
+  if (registerUser(username, password)) {
+    return res.status(201).json({ status: 'registered' });
+  }
+  return res.status(400).json({ error: 'user_exists' });
+});
+
+app.post('/login', (req, res) => {
+  const { username, password } = req.body || {};
+  if (authenticateUser(username, password)) {
+    return res.json({ status: 'ok' });
+  }
+  return res.status(401).json({ error: 'invalid_credentials' });
+});
+
+export default app;
+
+if (require.main === module) {
+  const port = process.env.PORT || 3000;
+  app.listen(port, () => console.log(`Server running on port ${port}`));
+}

--- a/tests/unit/auth/service.test.ts
+++ b/tests/unit/auth/service.test.ts
@@ -1,0 +1,10 @@
+import { registerUser, authenticateUser } from '../../../src/auth/service';
+
+describe('auth service', () => {
+  it('registers and authenticates a user', () => {
+    expect(registerUser('alice', 'secret')).toBe(true);
+    expect(registerUser('alice', 'secret')).toBe(false);
+    expect(authenticateUser('alice', 'secret')).toBe(true);
+    expect(authenticateUser('alice', 'wrong')).toBe(false);
+  });
+});

--- a/tests/unit/server.test.ts
+++ b/tests/unit/server.test.ts
@@ -1,0 +1,13 @@
+import request from 'supertest';
+import app from '../../src/server';
+
+describe('server endpoints', () => {
+  it('registers and logs in', async () => {
+    const reg = await request(app).post('/register').send({ username: 'bob', password: 'pass' });
+    expect(reg.status).toBe(201);
+    const loginOk = await request(app).post('/login').send({ username: 'bob', password: 'pass' });
+    expect(loginOk.status).toBe(200);
+    const loginFail = await request(app).post('/login').send({ username: 'bob', password: 'bad' });
+    expect(loginFail.status).toBe(401);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- switch README to Node.js/Express instructions
- add project plan under docs/specs
- bootstrap Node/TS server with auth service
- setup Jest config and unit tests

## Testing
- `npm test` *(fails: jest not installed)*
- `python -m unittest discover -s tests -v` *(fails: missing Flask)*